### PR TITLE
Annoying Notification's Animation

### DIFF
--- a/SwiftOverlays/SwiftOverlays.swift
+++ b/SwiftOverlays/SwiftOverlays.swift
@@ -435,15 +435,17 @@ public class SwiftOverlays: NSObject {
             notificationView = (sender as! UIView)
         }
         
+        bannerWindow?.backgroundColor = UIColor.clearColor()
         UIView.animateWithDuration(bannerDissapearAnimationDuration,
             animations: { () -> Void in
-                let frame = notificationView!.frame
-                notificationView!.frame = frame.offsetBy(dx: 0, dy: -frame.size.height)
+                if let frame = notificationView?.frame {
+                    notificationView?.frame = frame.offsetBy(dx: 0, dy: -frame.size.height)
+                }
             },
             completion: { (finished) -> Void in
-                notificationView!.removeFromSuperview()
+                notificationView?.removeFromSuperview()
                 
-                bannerWindow!.hidden = true
+                bannerWindow?.hidden = true
             }
         )
     }


### PR DESCRIPTION
Corrects the annoying notification's animation which may leave a colored background until complete. Also avoids force unwraps

Edit: This addresses the particular case where the notification's original height used to leave a black box behind as it animated closed.