### PR TITLE
Swift 3.1 @discardableResult warning of showNotificationOnTopOfStatusBar

### DIFF
--- a/SwiftOverlays/SwiftOverlays.swift
+++ b/SwiftOverlays/SwiftOverlays.swift
@@ -89,7 +89,6 @@ public extension UIViewController {
         - parameter duration: Amount of time until notification disappears
         - parameter animated: Should appearing be animated
     */
-    @discardableResult
     class func showNotificationOnTopOfStatusBar(_ notificationView: UIView, duration: TimeInterval, animated: Bool = true) {
         SwiftOverlays.showAnnoyingNotificationOnTopOfStatusBar(notificationView, duration: duration, animated: animated)
     }


### PR DESCRIPTION
New Swift 3.1 is showing warning:

SwiftOverlays.swift:93:5: @discardableResult declared on a function returning Void is unnecessary
```

    /**
        Shows notification on top of the status bar, similar to native local or remote notifications

        - parameter notificationView: View that will be shown as notification
        - parameter duration: Amount of time until notification disappears
        - parameter animated: Should appearing be animated
    */
    @discardableResult
    class func showNotificationOnTopOfStatusBar(_ notificationView: UIView, duration: TimeInterval, animated: Bool = true) {
        SwiftOverlays.showAnnoyingNotificationOnTopOfStatusBar(notificationView, duration: duration, animated: animated)
    }
```