### PR TITLE
added a method to close all notification on top status bar

### DIFF
--- a/SwiftOverlays/SwiftOverlays.swift
+++ b/SwiftOverlays/SwiftOverlays.swift
@@ -453,6 +453,10 @@ open class SwiftOverlays: NSObject {
         }
     }
     
+    open class func closeAllAnnoyingNotificationOnTopStatusBar(){
+        bannerWindow?.subviews.forEach({ $0.removeFromSuperview() })
+    }
+    
     open class func closeAnnoyingNotificationOnTopOfStatusBar(_ sender: AnyObject) {
         NSObject.cancelPreviousPerformRequests(withTarget: self)
     


### PR DESCRIPTION
Hi, I want to remove all showing notification before showing another one. 
Because somehow when I show another notification without close last notification, its not removed from superview (bannerWindow).
I'm not sure this is the correct approach, but it's working in my case